### PR TITLE
removed extra whitespace before href tag preventing app to load

### DIFF
--- a/src/components/AppToolbar.vue
+++ b/src/components/AppToolbar.vue
@@ -17,7 +17,7 @@
         >
       </v-text-field>
       <v-spacer></v-spacer>
-      <v-btn  href="mailto:wangqiangshen@gmail.com">
+      <v-btn href="mailto:wangqiangshen@gmail.com">
         Hire Me
       </v-btn>      
       <v-btn icon href="https://github.com/tookit/vue-material-admin">


### PR DESCRIPTION
With the current master branch, the app do not start due to an eslint error : 

```
WARNING  Compiled with 1 warnings                                                                                                                                                  00:35:52


  ✘  https://google.com/#q=vue%2Fno-multi-spaces  Multiple spaces found before 'href'
  src/components/AppToolbar.vue:20:13
        <v-btn  href="mailto:wangqiangshen@gmail.com">
               ^


✘ 1 problem (1 error, 0 warnings)


Errors:
  1  https://google.com/#q=vue%2Fno-multi-spaces

```

This PR, while minimal, fixes that issue.